### PR TITLE
Allow custom Graph base URL and fix registration tests

### DIFF
--- a/pkg/whatsapp/client.go
+++ b/pkg/whatsapp/client.go
@@ -48,8 +48,8 @@ func NewClient(o Options) (*Client, error) {
 		doer = httpx.New(httpx.Options{MaxRetries: o.RetryMax})
 	}
 
-	phoneAPI := graph.NewPhoneAPI(doer, o.TokenProvider, o.Version, o.WABAID)
-	regAPI := graph.NewRegistrationAPI(doer, o.TokenProvider, o.Version, o.PhoneNumberID)
+	phoneAPI := graph.NewPhoneAPI(doer, o.TokenProvider, o.Version, o.WABAID, o.BaseURL)
+	regAPI := graph.NewRegistrationAPI(doer, o.TokenProvider, o.Version, o.PhoneNumberID, o.BaseURL)
 
 	c := &Client{
 		Phone:         services.NewPhoneService(phoneAPI),

--- a/pkg/whatsapp/services/registration_service_test.go
+++ b/pkg/whatsapp/services/registration_service_test.go
@@ -110,16 +110,5 @@ func TestRegistration_ErrorGraphPayload(t *testing.T) {
 func ptr(s string) *string { return &s }
 
 // small helper: errors.As across go versions used in tests only
-func As(err error, target any) bool { return errorsxAs(err, target) }
-
-// shim to avoid importing "errors" in multiple places
-func errorsxAs(err error, target any) bool {
-	type as interface{ As(error, any) bool }
-	// Use std errors.As via a tiny indirection to keep this file focused
-	return func(e error, t any) bool {
-		return (func() bool {
-			// inline: stdlib
-			return errors.As(e, &t)
-		})()
-	}(err, target)
-}
+// It forwards directly to the stdlib errors.As to ensure the target is populated.
+func As(err error, target any) bool { return errors.As(err, target) }

--- a/pkg/whatsapp/transport/graph/phone.go
+++ b/pkg/whatsapp/transport/graph/phone.go
@@ -19,13 +19,16 @@ type PhoneAPI struct {
 	baseURL       string // default: https://graph.facebook.com
 }
 
-func NewPhoneAPI(doer ports.HTTPDoer, token ports.TokenProvider, version, wabaID string) *PhoneAPI {
+func NewPhoneAPI(doer ports.HTTPDoer, token ports.TokenProvider, version, wabaID, baseURL string) *PhoneAPI {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
 	return &PhoneAPI{
 		doer:          doer,
 		tokenProvider: token,
 		version:       version,
 		wabaID:        wabaID,
-		baseURL:       "https://graph.facebook.com",
+		baseURL:       baseURL,
 	}
 }
 

--- a/pkg/whatsapp/transport/graph/registration.go
+++ b/pkg/whatsapp/transport/graph/registration.go
@@ -27,13 +27,16 @@ type RegistrationAPI struct {
 var _ ports.RegistrationAPI = (*RegistrationAPI)(nil)
 
 // NewRegistrationAPI wires the adapter with hexagonal dependencies and static params.
-func NewRegistrationAPI(doer ports.HTTPDoer, token ports.TokenProvider, version, phoneNumberID string) *RegistrationAPI {
+func NewRegistrationAPI(doer ports.HTTPDoer, token ports.TokenProvider, version, phoneNumberID, baseURL string) *RegistrationAPI {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
 	return &RegistrationAPI{
 		doer:          doer,
 		tokenProvider: token,
 		version:       version,
 		phoneNumberID: phoneNumberID,
-		baseURL:       DefaultBaseURL,
+		baseURL:       baseURL,
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow custom base URL for registration and phone APIs
- keep CLI flag descriptions and output in English
- fix helper that wraps errors.As in registration service tests