### PR TITLE
Add tests for errors and options

### DIFF
--- a/internal/httpx/backoff_test.go
+++ b/internal/httpx/backoff_test.go
@@ -1,0 +1,31 @@
+package httpx
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+)
+
+// TestBackoffWithinBase ensures the backoff stays within the expected range
+// when the calculated value is below the max cap.
+func TestBackoffWithinBase(t *testing.T) {
+	rand.Seed(1)
+	base := 100 * time.Millisecond
+	max := time.Second
+	got := backoff(1, base, max)
+	if got < 100*time.Millisecond || got > 200*time.Millisecond {
+		t.Fatalf("backoff out of range: %v", got)
+	}
+}
+
+// TestBackoffCapped ensures the backoff respects the max cap when the
+// exponential growth would exceed it.
+func TestBackoffCapped(t *testing.T) {
+	rand.Seed(1)
+	base := 100 * time.Millisecond
+	max := 150 * time.Millisecond // much lower than base*2^attempt
+	got := backoff(5, base, max)
+	if got < max/2 || got > max {
+		t.Fatalf("backoff not capped correctly: %v", got)
+	}
+}

--- a/pkg/errorsx/errors_test.go
+++ b/pkg/errorsx/errors_test.go
@@ -1,0 +1,103 @@
+package errorsx
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestHTTPErrorError(t *testing.T) {
+	var he *HTTPError
+	if he.Error() != "<nil>" {
+		t.Fatalf("nil receiver error != <nil>")
+	}
+	he = &HTTPError{Method: "GET", URL: "u", StatusCode: 500, Status: "500", FBTraceID: "abc"}
+	if !strings.Contains(he.Error(), "fb-trace-id=abc") {
+		t.Fatalf("expected fb-trace-id in error: %s", he.Error())
+	}
+	he.FBTraceID = ""
+	if strings.Contains(he.Error(), "fb-trace-id") {
+		t.Fatalf("did not expect fb-trace-id in error: %s", he.Error())
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	cases := []struct {
+		code int
+		want bool
+	}{
+		{http.StatusTooManyRequests, true},
+		{500, true},
+		{http.StatusNotImplemented, false},
+		{http.StatusHTTPVersionNotSupported, false},
+		{400, false},
+	}
+	for _, tc := range cases {
+		if got := IsRetryable(&HTTPError{StatusCode: tc.code}); got != tc.want {
+			t.Fatalf("code %d: want %v got %v", tc.code, tc.want, got)
+		}
+	}
+	if IsRetryable(errors.New("x")) {
+		t.Fatalf("non HTTPError should not be retryable")
+	}
+}
+
+func TestNewHTTPErrorFromResponse(t *testing.T) {
+	he := NewHTTPErrorFromResponse(nil, []byte("b"))
+	if he.StatusCode != 0 || he.Status != "<nil response>" {
+		t.Fatalf("unexpected nil response handling: %+v", he)
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "http://x", nil)
+	resp := &http.Response{StatusCode: 404, Status: "404", Header: http.Header{"X-Fb-Trace-Id": {"id"}}, Request: req}
+	he = NewHTTPErrorFromResponse(resp, []byte("b"))
+	if he.FBTraceID != "id" {
+		t.Fatalf("expected fbtrace id set, got %s", he.FBTraceID)
+	}
+}
+
+func TestGraphError(t *testing.T) {
+	var ge *GraphError
+	if ge.Error() != "<nil>" {
+		t.Fatalf("nil graph error != <nil>")
+	}
+	req, _ := http.NewRequest(http.MethodGet, "http://x", nil)
+	resp := &http.Response{StatusCode: 400, Status: "400", Header: http.Header{"Content-Type": {"application/json"}}, Request: req}
+	body := []byte(`{"error":{"message":"bad","type":"x","code":10,"fbtrace_id":"tid"}}`)
+	ge = TryParseGraphError(resp, body)
+	if ge.Detail.Message != "bad" || ge.HTTP.FBTraceID != "tid" {
+		t.Fatalf("unexpected parse: %+v", ge)
+	}
+	if !errors.Is(ge, ge.HTTP) {
+		t.Fatalf("unwrap not working")
+	}
+	if !strings.Contains(ge.Error(), "bad") {
+		t.Fatalf("error string missing detail: %s", ge.Error())
+	}
+
+	// Invalid JSON path -> Raw preserved and message empty
+	badBody := []byte("not-json")
+	ge2 := TryParseGraphError(resp, badBody)
+	if ge2.Detail.Message != "" || string(ge2.Raw) != string(badBody) {
+		t.Fatalf("unexpected fallback parse: %+v", ge2)
+	}
+	if !strings.Contains(ge2.Error(), "undecoded") {
+		t.Fatalf("unexpected error string: %s", ge2.Error())
+	}
+}
+
+func TestValidationErrorError(t *testing.T) {
+	var v *ValidationError
+	if v.Error() != "<nil>" {
+		t.Fatalf("nil validation error != <nil>")
+	}
+	v = &ValidationError{Field: "f", Reason: "r", Op: "op"}
+	if !strings.Contains(v.Error(), "field=f") {
+		t.Fatalf("unexpected error: %s", v.Error())
+	}
+	v = &ValidationError{Reason: "r", Op: "op"}
+	if strings.Contains(v.Error(), "field=") {
+		t.Fatalf("did not expect field info: %s", v.Error())
+	}
+}

--- a/pkg/whatsapp/domain/webhooks_test.go
+++ b/pkg/whatsapp/domain/webhooks_test.go
@@ -1,0 +1,14 @@
+package domain
+
+import "testing"
+
+func TestParseWebhookEvent(t *testing.T) {
+	ok := []byte(`{"object":"whatsapp","entry":[]}`)
+	if _, err := ParseWebhookEvent(ok); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	bad := []byte("not-json")
+	if _, err := ParseWebhookEvent(bad); err == nil {
+		t.Fatalf("expected error for invalid json")
+	}
+}

--- a/pkg/whatsapp/options_test.go
+++ b/pkg/whatsapp/options_test.go
@@ -1,0 +1,76 @@
+package whatsapp
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+type stubTokenProvider struct{}
+
+func (stubTokenProvider) Token(ctx context.Context) (string, error) { return "token", nil }
+func (stubTokenProvider) Refresh(ctx context.Context) error         { return nil }
+
+func validOpts() Options {
+	return Options{
+		Version:       "v1.0",
+		WABAID:        "12345678",
+		PhoneNumberID: "87654321",
+		TokenProvider: stubTokenProvider{},
+	}
+}
+
+func TestOptionsValidate(t *testing.T) {
+	o := validOpts()
+	if err := o.Validate(); err != nil {
+		t.Fatalf("valid options failed: %v", err)
+	}
+	cases := []struct {
+		name string
+		mod  func(o *Options)
+	}{
+		{"nil", func(o *Options) { *o = Options{} }},
+		{"no version", func(o *Options) { o.Version = "" }},
+		{"bad version", func(o *Options) { o.Version = "20.0" }},
+		{"no waba", func(o *Options) { o.WABAID = "" }},
+		{"no phone", func(o *Options) { o.PhoneNumberID = "" }},
+		{"no token", func(o *Options) { o.TokenProvider = nil }},
+	}
+	for _, tc := range cases {
+		o := validOpts()
+		tc.mod(&o)
+		if err := o.Validate(); err == nil {
+			t.Fatalf("%s: expected error", tc.name)
+		}
+	}
+}
+
+func TestOptionsWithDefaults(t *testing.T) {
+	o := validOpts()
+	d := o.withDefaults()
+	if d.Timeout != 10*time.Second || d.RetryMax != 3 {
+		t.Fatalf("unexpected defaults: %+v", d)
+	}
+	o.Timeout = time.Second
+	o.RetryMax = 5
+	d = o.withDefaults()
+	if d.Timeout != o.Timeout || d.RetryMax != o.RetryMax {
+		t.Fatalf("non-zero values should be kept")
+	}
+}
+
+func TestOptionsStringMasks(t *testing.T) {
+	o := validOpts()
+	o.BaseURL = "https://example"
+	o.Timeout = time.Second
+	o.RetryMax = 5
+	o.UserAgent = "ua"
+	s := o.String()
+	if !strings.Contains(s, "Options{Version=v1.0") {
+		t.Fatalf("unexpected string: %s", s)
+	}
+	if !strings.Contains(s, "WABAID=12****78") || !strings.Contains(s, "PhoneNumberID=87****21") {
+		t.Fatalf("ids not masked: %s", s)
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for http client retry logic
- cover error helpers and options validation
- parse webhook event test
