### PR TITLE
Add HTTP handler for WhatsApp webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ whatsapp-sdk-go/
 
     * **Entrega**: payloads com `entry`, `changes`, `messages`, `statuses`, `errors`
     * **Serviço**: `WebhookService` (validação de verify token, parsing e utilitários)
+    * **Adapter**: `transport/webhook` handler HTTP para verificação e dispatch
     * **Modelos**: `domain.WebhookEvent`, `domain.MessageEvent`, `domain.StatusEvent`
 
 > Observação: nomes de modelos são ilustrativos e serão finalizados ao implementar a serialização oficial.

--- a/examples/webhook_receiver/main.go
+++ b/examples/webhook_receiver/main.go
@@ -3,13 +3,14 @@ package main
 import (
 	"context"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"os"
 
+	"github.com/diegoyosiura/whatsapp-sdk-go/pkg/whatsapp/domain"
 	"github.com/diegoyosiura/whatsapp-sdk-go/pkg/whatsapp/ports"
 	"github.com/diegoyosiura/whatsapp-sdk-go/pkg/whatsapp/services"
+	"github.com/diegoyosiura/whatsapp-sdk-go/pkg/whatsapp/transport/webhook"
 )
 
 // Minimal SecretsProvider backed by environment variables for the example only.
@@ -23,67 +24,19 @@ func (s envSecrets) Get(ctx context.Context, key ports.SecretKey) (string, error
 	return v, nil
 }
 
+// logHandler logs webhook events; replace with your business logic.
+type logHandler struct{}
+
+func (logHandler) OnMessage(m domain.InboundMessage) { log.Printf("incoming message id=%s", m.ID) }
+func (logHandler) OnStatus(s domain.MessageStatus) {
+	log.Printf("status id=%s status=%s", s.ID, s.Status)
+}
+
 func main() {
 	secrets := envSecrets{}
 	svc := services.NewWebhookService(secrets)
-
-	http.HandleFunc("/webhook", func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		switch r.Method {
-		case http.MethodGet:
-			// Verification handshake
-			mode := r.URL.Query().Get("hub.mode")
-			token := r.URL.Query().Get("hub.verify_token")
-			challenge := r.URL.Query().Get("hub.challenge")
-
-			if mode != "subscribe" {
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write([]byte("invalid mode"))
-				return
-			}
-			if err := svc.ValidateVerifyToken(ctx, token); err != nil {
-				w.WriteHeader(http.StatusForbidden)
-				_, _ = w.Write([]byte("verify token mismatch"))
-				return
-			}
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(challenge))
-			return
-
-		case http.MethodPost:
-			// Signature verification + parse
-			raw, err := io.ReadAll(r.Body)
-			if err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write([]byte("cannot read body"))
-				return
-			}
-			sig := r.Header.Get("X-Hub-Signature-256")
-			if err := svc.VerifySignature(ctx, raw, sig); err != nil {
-				w.WriteHeader(http.StatusForbidden)
-				_, _ = w.Write([]byte("invalid signature"))
-				return
-			}
-
-			event, err := svc.ParseEvent(ctx, raw)
-			if err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write([]byte("invalid payload"))
-				return
-			}
-
-			// Business hook: log basic info. Replace with your dispatcher.
-			log.Printf("incoming webhook: object=%s entries=%d", event.Object, len(event.Entry))
-
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("ok"))
-			return
-
-		default:
-			w.WriteHeader(http.StatusMethodNotAllowed)
-			return
-		}
-	})
+	dispatcher := services.NewWebhookDispatcher(logHandler{})
+	http.Handle("/webhook", webhook.NewHandler(svc, dispatcher))
 
 	addr := ":8080"
 	log.Printf("listening on %s", addr)

--- a/pkg/whatsapp/transport/webhook/handler.go
+++ b/pkg/whatsapp/transport/webhook/handler.go
@@ -1,0 +1,66 @@
+package webhook
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/diegoyosiura/whatsapp-sdk-go/pkg/whatsapp/services"
+)
+
+// Handler is an HTTP adapter for WhatsApp webhooks.
+// It uses WebhookService for validation/parsing and optionally dispatches
+// events to a WebhookDispatcher.
+type Handler struct {
+	Service    *services.WebhookService
+	Dispatcher *services.WebhookDispatcher
+}
+
+func NewHandler(svc *services.WebhookService, dispatcher *services.WebhookDispatcher) *Handler {
+	return &Handler{Service: svc, Dispatcher: dispatcher}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	switch r.Method {
+	case http.MethodGet:
+		mode := r.URL.Query().Get("hub.mode")
+		token := r.URL.Query().Get("hub.verify_token")
+		challenge := r.URL.Query().Get("hub.challenge")
+		if mode != "subscribe" {
+			http.Error(w, "invalid mode", http.StatusBadRequest)
+			return
+		}
+		if err := h.Service.ValidateVerifyToken(ctx, token); err != nil {
+			http.Error(w, "verify token mismatch", http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, challenge)
+		return
+	case http.MethodPost:
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "cannot read body", http.StatusBadRequest)
+			return
+		}
+		sig := r.Header.Get("X-Hub-Signature-256")
+		if err := h.Service.VerifySignature(ctx, raw, sig); err != nil {
+			http.Error(w, "invalid signature", http.StatusForbidden)
+			return
+		}
+		event, err := h.Service.ParseEvent(ctx, raw)
+		if err != nil {
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+		if h.Dispatcher != nil {
+			h.Dispatcher.Dispatch(event)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+		return
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+}

--- a/pkg/whatsapp/transport/webhook/handler_test.go
+++ b/pkg/whatsapp/transport/webhook/handler_test.go
@@ -1,0 +1,68 @@
+package webhook_test
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	intfakes "github.com/diegoyosiura/whatsapp-sdk-go/internal/testutils/whatsapp/ports"
+	"github.com/diegoyosiura/whatsapp-sdk-go/pkg/whatsapp/domain"
+	"github.com/diegoyosiura/whatsapp-sdk-go/pkg/whatsapp/ports"
+	"github.com/diegoyosiura/whatsapp-sdk-go/pkg/whatsapp/services"
+	"github.com/diegoyosiura/whatsapp-sdk-go/pkg/whatsapp/transport/webhook"
+)
+
+type fakeHandler struct{ messages []domain.InboundMessage }
+
+func (f *fakeHandler) OnMessage(m domain.InboundMessage) { f.messages = append(f.messages, m) }
+func (f *fakeHandler) OnStatus(domain.MessageStatus)     {}
+
+func TestHandler_GetVerify(t *testing.T) {
+	fp := &intfakes.FakeSecretsProvider{Secrets: map[ports.SecretKey]string{
+		ports.VerifyTokenKey: "tkn",
+	}}
+	svc := services.NewWebhookService(fp)
+	h := webhook.NewHandler(svc, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/webhook?hub.mode=subscribe&hub.verify_token=tkn&hub.challenge=abc", nil)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK || rr.Body.String() != "abc" {
+		t.Fatalf("unexpected response: code=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandler_PostDispatch(t *testing.T) {
+	payload := []byte(`{"object":"whatsapp_business_account","entry":[{"id":"x","changes":[{"value":{"messages":[{"id":"m1"}]}}]}]}`)
+	appSecret := "secret"
+	mac := hmac.New(sha256.New, []byte(appSecret))
+	mac.Write(payload)
+	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	fp := &intfakes.FakeSecretsProvider{Secrets: map[ports.SecretKey]string{
+		ports.AppSecretKey: appSecret,
+	}}
+	svc := services.NewWebhookService(fp)
+	fh := &fakeHandler{}
+	dispatcher := services.NewWebhookDispatcher(fh)
+	h := webhook.NewHandler(svc, dispatcher)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(payload))
+	req.Header.Set("X-Hub-Signature-256", sig)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", rr.Code)
+	}
+	if len(fh.messages) != 1 || fh.messages[0].ID != "m1" {
+		t.Fatalf("dispatcher not invoked: %+v", fh.messages)
+	}
+}


### PR DESCRIPTION
## Summary
- add transport/webhook HTTP handler for verification and dispatch
- wire new handler into webhook example
- document webhook adapter in README